### PR TITLE
Travis build: load bundle only & not start them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,16 @@ install:
   # Prep our sandbox with some temporary credentials for CI
   - ./bin/create-credentials.sh
   # Warm up some caches so that our tests don't timeout
-  - sandbox run 2.0.5 -f visualization -f monitoring > /dev/null
+  - sandbox run 2.0.5 --no-default-features > /dev/null
   - conduct load -q cassandra
   - conduct load -q cinnamon-grafana-docker
+  - conduct load -q cinnamon-grafana
   - conduct load -q eslite
   - conduct load -q reactive-maps-backend-region
   - conduct load -q reactive-maps-backend-summary
+  - conduct load -q visualizer
+  - conduct load -q conductr-elasticsearch
+  - conduct load -q conductr-kibana
   - sandbox stop
   # Tests go faster if we do this... less interactions with bintray etc.
   - export CONDUCTR_OFFLINE_MODE=1


### PR DESCRIPTION
This is sufficient as we'd like to prepopulate the bundle cache.